### PR TITLE
Fix multiple scenes error

### DIFF
--- a/booleanOps.py
+++ b/booleanOps.py
@@ -27,7 +27,7 @@ class BooleanUnionOperator(bpy.types.Operator):
                 md.object = SelectedObject       
                 # apply the modifier
                 bpy.ops.object.modifier_apply(apply_as='DATA', modifier="booleanunion")
-                bpy.data.scenes[0].objects.unlink(SelectedObject)
+                bpy.data.scenes.get(context.scene.name).objects.unlink(SelectedObject)
                 bpy.data.objects.remove(SelectedObject)
         
         return {'FINISHED'}
@@ -61,7 +61,7 @@ class BooleanDifferenceOperator(bpy.types.Operator):
                 md.object = SelectedObject       
                 # apply the modifier
                 bpy.ops.object.modifier_apply(apply_as='DATA', modifier="booleandifference")
-                bpy.data.scenes[0].objects.unlink(SelectedObject)
+                bpy.data.scenes.get(context.scene.name).objects.unlink(SelectedObject)
                 bpy.data.objects.remove(SelectedObject)
         
         return {'FINISHED'}
@@ -96,7 +96,7 @@ class BooleanIntersectOperator(bpy.types.Operator):
                 
                 # apply the modifier
                 bpy.ops.object.modifier_apply(apply_as='DATA', modifier="booleanintersect")
-                bpy.data.scenes[0].objects.unlink(SelectedObject)
+                bpy.data.scenes.get(context.scene.name).objects.unlink(SelectedObject)
                 bpy.data.objects.remove(SelectedObject)
         
         return {'FINISHED'}
@@ -174,7 +174,7 @@ class BooleanSeparateOperator(bpy.types.Operator):
                 helper.objSelectFaces(SelectedObject, 'INVERT')
                 
                 #delete the copy of the active object
-                bpy.data.scenes[0].objects.unlink(activeObjCopy)
+                bpy.data.scenes.get(context.scene.name).objects.unlink(activeObjCopy)
                 bpy.data.objects.remove(activeObjCopy)
         
         helper.objSelectFaces(SelectedObjCopy, 'SELECT')
@@ -189,7 +189,7 @@ class BooleanSeparateOperator(bpy.types.Operator):
         bpy.ops.object.modifier_apply(apply_as='DATA', modifier="sepDifference")
         
         #delete the copy of the selected object
-        bpy.data.scenes[0].objects.unlink(SelectedObjCopy)
+        bpy.data.scenes.get(context.scene.name).objects.unlink(SelectedObjCopy)
         bpy.data.objects.remove(SelectedObjCopy)
         
         bpy.context.active_object.select = True

--- a/meshExtract.py
+++ b/meshExtract.py
@@ -30,7 +30,7 @@ class MaskExtractOperator(bpy.types.Operator):
             context.selected_objects[0].name.startswith("Extracted."):
             rem = context.selected_objects[0]
             remname = rem.data.name
-            bpy.data.scenes[0].objects.unlink(rem)
+            bpy.data.scenes.get(context.scene.name).objects.unlink(rem)
             bpy.data.objects.remove(rem)
             # remove mesh to prevent memory being cluttered up with hundreds of high-poly objects
             bpy.data.meshes.remove(bpy.data.meshes[remname])

--- a/utilOps.py
+++ b/utilOps.py
@@ -108,7 +108,7 @@ class RemeshOperator(bpy.types.Operator):
             md2.target = obCopy
             bpy.ops.object.modifier_apply(apply_as='DATA', modifier="RemeshShrinkwrap")
             
-            bpy.data.scenes[0].objects.unlink(obCopy)
+            bpy.data.scenes.get(context.scene.name).objects.unlink(obCopy)
             bpy.data.objects.remove(obCopy)
         
         bpy.ops.object.mode_set(mode=oldMode)


### PR DESCRIPTION
When index [0] is not the current scene unexpected things could happen like missing object. This fix use the scene name from the context to get current scene.

Sorry for the confusion #5 missed some files. 
